### PR TITLE
Fix broken google visualization TableNumberFormat

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     function drawTable() {
       var data = google.visualization.arrayToDataTable(array_salarios);
 
-      var formatter = new google.visualization.TableNumberFormat({
+      var formatter = new google.visualization.NumberFormat({
         prefix: "R$", 
         pattern: 'R$ #,###,###.##', 
         negativeColor: 'red', 


### PR DESCRIPTION
The `TableNumberFormat` was removed, you should use `NumberFormat`, so your data table is broken.

Here, some links: http://stackoverflow.com/questions/20234490/why-did-my-previously-working-google-visualization-charts-stop-working-after-nov
