### PR TITLE
Always show two decimal numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
       var formatter = new google.visualization.NumberFormat({
         prefix: "R$", 
-        pattern: 'R$ #,###,###.##', 
+        pattern: 'R$ #,###,###.00', 
         negativeColor: 'red', 
         negativeParens: true
       });


### PR DESCRIPTION
In the case of an int number, this number format show the decimal number as 00.

e.g. 1234 -> "1,234.00" instead of "1,234".
